### PR TITLE
功能: 重構 ModalDialog 並新增單/批量成績編輯與 CSV 匯出功能

### DIFF
--- a/hello-vue3/src/components/Competition/CompetitionForm.vue
+++ b/hello-vue3/src/components/Competition/CompetitionForm.vue
@@ -9,12 +9,11 @@
         class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
       >
         <option value="">請選擇競賽類別</option>
-        <option value="國際性">国际性</option>
-        <option value="全國性">全国性</option>
-        <option value="地區性">地区性</option>
+        <option value="國際性">國際性</option>
+        <option value="全國性">全國性</option>
+        <option value="地區性">地區性</option>
         <option value="教育部">教育部</option>
-        <option value="大陸、港、澳地區">大陆、港、澳地区</option>
-        <option value="校內競賽">校内竞赛</option>
+        <option value="校內競賽">校內競賽</option>
       </select>
       <!-- 競賽類別條件提示 -->
       <div v-if="modelValue.competitionType === '國際性'" class="text-sm text-gray-600 mt-1">
@@ -23,9 +22,6 @@
       </div>
       <div v-if="modelValue.competitionType === '教育部'" class="text-sm text-gray-600 mt-1">
         以教育部名義舉辦之專業技(藝)能競賽。
-      </div>
-      <div v-if="modelValue.competitionType === '大陸、港、澳地區'" class="text-sm text-gray-600 mt-1">
-        大陸、港、澳地區應包含三個以上不同單位參與競賽。
       </div>
     </div>
 

--- a/hello-vue3/src/components/Competition/CompetitionForm.vue
+++ b/hello-vue3/src/components/Competition/CompetitionForm.vue
@@ -6,15 +6,15 @@
       <select
         :value="modelValue.competitionType"
         @change="updateField('competitionType', $event.target.value)"
-        class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+        class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
       >
         <option value="">請選擇競賽類別</option>
-        <option value="國際性">國際性</option>
-        <option value="全國性">全國性</option>
-        <option value="地區性">地區性</option>
+        <option value="國際性">国际性</option>
+        <option value="全國性">全国性</option>
+        <option value="地區性">地区性</option>
         <option value="教育部">教育部</option>
-        <option value="大陸、港、澳地區">大陸、港、澳地區</option>
-        <option value="校內競賽">校內競賽</option>
+        <option value="大陸、港、澳地區">大陆、港、澳地区</option>
+        <option value="校內競賽">校内竞赛</option>
       </select>
       <!-- 競賽類別條件提示 -->
       <div v-if="modelValue.competitionType === '國際性'" class="text-sm text-gray-600 mt-1">
@@ -37,7 +37,7 @@
         :value="modelValue.awardRank"
         @input="updateField('awardRank', $event.target.value)"
         placeholder="請填寫「第X名」或佳作"
-        class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+        class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
       />
     </div>
 
@@ -49,7 +49,7 @@
         :value="modelValue.competitionName"
         @input="updateField('competitionName', $event.target.value)"
         placeholder="請輸入競賽名稱"
-        class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+        class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
         required
       />
     </div>
@@ -60,7 +60,7 @@
       <select
         :value="modelValue.competitionNature"
         @change="updateField('competitionNature', $event.target.value)"
-        class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+        class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
       >
         <option value="個人獎項">個人獎項</option>
         <option value="團體獎項">團體獎項</option>
@@ -73,7 +73,7 @@
       <select
         :value="modelValue.participationLevel"
         @change="updateField('participationLevel', $event.target.value)"
-        class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+        class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
       >
         <option value="">請選擇參與程度</option>
         <option value="參賽">參賽</option>
@@ -90,7 +90,7 @@
         :value="modelValue.projectName"
         @input="updateField('projectName', $event.target.value)"
         placeholder="請輸入作品名稱或競賽項目"
-        class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+        class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
         required
       />
     </div>
@@ -103,7 +103,7 @@
         :value="modelValue.totalEntries"
         @input="updateField('totalEntries', $event.target.value)"
         placeholder="共多少競爭對手參賽"
-        class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+        class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
         required
       />
     </div>
@@ -116,7 +116,7 @@
         :value="modelValue.hostOrganization"
         @input="updateField('hostOrganization', $event.target.value)"
         placeholder="請輸入主辦單位"
-        class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+        class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
         required
       />
     </div>
@@ -129,7 +129,7 @@
           type="date"
           :value="modelValue.startDate"
           @input="updateField('startDate', $event.target.value)"
-          class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+          class="flex-1 max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
           required
         />
         <span>~</span>
@@ -137,7 +137,7 @@
           type="date"
           :value="modelValue.endDate"
           @input="updateField('endDate', $event.target.value)"
-          class="w-full px-3 py-2 border border-stone-300 rounded-lg"
+          class="flex-1 max-w-full px-3 py-2 border border-stone-300 rounded-lg box-border"
           required
         />
       </div>
@@ -150,7 +150,7 @@
         :value="modelValue.summary"
         @input="updateField('summary', $event.target.value)"
         placeholder="請簡要條例說明，文限200字"
-        class="w-full px-3 py-2 border border-stone-300 rounded-lg bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none min-h-[100px]"
+        class="w-full max-w-full px-3 py-2 border border-stone-300 rounded-lg bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none min-h-[100px] box-border"
         maxlength="200"
         required
       ></textarea>
@@ -170,10 +170,9 @@ const props = defineProps({
   }
 });
 
-const emit = defineEmits(['update:modelValue']); // ✅ 修正點在這裡！
+const emit = defineEmits(['update:modelValue']);
 
 const updateField = (field, value) => {
   emit('update:modelValue', { ...props.modelValue, [field]: value });
 };
-
 </script>

--- a/hello-vue3/src/components/Competition/Supervisors.vue
+++ b/hello-vue3/src/components/Competition/Supervisors.vue
@@ -19,15 +19,9 @@
           :value="supervisor.name"
           @input="updateSupervisor(index, 'name', $event.target.value)"
           placeholder="姓名"
-          class="flex-1 px-3 py-2 border border-stone-300 rounded-lg max-w-[120px]"
+          class="flex-1 px-3 py-2 border border-stone-300 rounded-lg max-w-[150px]"
         />
-        <input
-          type="text"
-          :value="supervisor.title"
-          @input="updateSupervisor(index, 'title', $event.target.value)"
-          placeholder="職稱"
-          class="flex-1 px-3 py-2 border border-stone-300 rounded-lg max-w-[120px]"
-        />
+
         <input
           type="text"
           :value="supervisor.id"

--- a/hello-vue3/src/components/Grades/ModalDialog.vue
+++ b/hello-vue3/src/components/Grades/ModalDialog.vue
@@ -2,19 +2,15 @@
   <div
     v-if="visible"
     class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-300"
-    @click.self="$emit('close')"
+    @click.self="emitClose"
   >
     <div
-      class="bg-white rounded-xl p-6 w-full max-w-lg mx-4 shadow-2xl transform transition-all duration-300 scale-95 animate-fade-in"
+      class="bg-white rounded-xl p-6 w-full max-w-lg mx-4 shadow-2xl transform transition-all duration-300 animate-fade-in"
     >
       <!-- 標題 -->
       <div class="flex justify-between items-center mb-4">
         <h3 class="text-xl font-semibold text-stone-950">{{ message }}</h3>
-        <button
-          @click="$emit('close')"
-          class="text-stone-500 hover:text-stone-950 transition-colors"
-          aria-label="關閉彈窗"
-        >
+        <button @click="emitClose" class="text-stone-500 hover:text-stone-950" aria-label="關閉">
           <XIcon class="w-6 h-6" />
         </button>
       </div>
@@ -27,17 +23,16 @@
       <!-- 按鈕 -->
       <div class="flex justify-end space-x-4">
         <button
-          @click="$emit('cancel')"
-          class="px-4 py-2 bg-stone-200 text-stone-950 rounded-lg font-semibold hover:bg-stone-300 transition-all duration-300"
+          @click="emitCancel"
+          class="px-4 py-2 bg-stone-200 text-stone-950 rounded-lg font-semibold hover:bg-stone-300 transition-all"
         >
           取消
         </button>
         <button
-          @click="$emit('confirm')"
-          class="px-4 py-2 bg-Ghibli-blue text-white rounded-lg font-semibold hover:bg-Ghibli-yellow hover:text-stone-950 transition-all duration-300"
-          :class="{ 'bg-Ghibli-green': pendingAction === 'export' }"
+          @click="emitConfirm"
+          class="px-4 py-2 bg-Ghibli-blue text-white rounded-lg font-semibold hover:bg-Ghibli-yellow transition-all"
         >
-          {{ pendingAction === 'edit' ? '確認儲存' : '確認導出' }}
+          確認儲存
         </button>
       </div>
     </div>
@@ -45,39 +40,28 @@
 </template>
 
 <script setup>
+import { defineProps, defineEmits } from 'vue';
 import { XIcon } from '@heroicons/vue/24/outline';
 
+// 定義接收的 props，無需指定變數名
 defineProps({
-  message: {
-    type: String,
-    required: true
-  },
-  pendingAction: {
-    type: String,
-    default: 'edit'
-  },
-  visible: {
-    type: Boolean,
-    default: false
-  }
+  message: { type: String, required: true },
+  visible: { type: Boolean, default: false }
 });
 
-defineEmits(['confirm', 'cancel', 'close']);
+const emit = defineEmits(['confirm', 'cancel', 'close']);
+
+function emitConfirm() { emit('confirm'); }
+function emitCancel()  { emit('cancel'); }
+function emitClose()   { emit('close'); }
 </script>
 
 <style scoped>
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.95) }
+  to   { opacity: 1; transform: scale(1) }
+}
 .animate-fade-in {
   animation: fadeIn 0.3s ease-out forwards;
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
 }
 </style>

--- a/hello-vue3/src/components/Grades/ModalDialog.vue
+++ b/hello-vue3/src/components/Grades/ModalDialog.vue
@@ -1,0 +1,83 @@
+<template>
+  <div
+    v-if="visible"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity duration-300"
+    @click.self="$emit('close')"
+  >
+    <div
+      class="bg-white rounded-xl p-6 w-full max-w-lg mx-4 shadow-2xl transform transition-all duration-300 scale-95 animate-fade-in"
+    >
+      <!-- 標題 -->
+      <div class="flex justify-between items-center mb-4">
+        <h3 class="text-xl font-semibold text-stone-950">{{ message }}</h3>
+        <button
+          @click="$emit('close')"
+          class="text-stone-500 hover:text-stone-950 transition-colors"
+          aria-label="關閉彈窗"
+        >
+          <XIcon class="w-6 h-6" />
+        </button>
+      </div>
+
+      <!-- 內容插槽 -->
+      <div class="mb-6">
+        <slot />
+      </div>
+
+      <!-- 按鈕 -->
+      <div class="flex justify-end space-x-4">
+        <button
+          @click="$emit('cancel')"
+          class="px-4 py-2 bg-stone-200 text-stone-950 rounded-lg font-semibold hover:bg-stone-300 transition-all duration-300"
+        >
+          取消
+        </button>
+        <button
+          @click="$emit('confirm')"
+          class="px-4 py-2 bg-Ghibli-blue text-white rounded-lg font-semibold hover:bg-Ghibli-yellow hover:text-stone-950 transition-all duration-300"
+          :class="{ 'bg-Ghibli-green': pendingAction === 'export' }"
+        >
+          {{ pendingAction === 'edit' ? '確認儲存' : '確認導出' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { XIcon } from '@heroicons/vue/24/outline';
+
+defineProps({
+  message: {
+    type: String,
+    required: true
+  },
+  pendingAction: {
+    type: String,
+    default: 'edit'
+  },
+  visible: {
+    type: Boolean,
+    default: false
+  }
+});
+
+defineEmits(['confirm', 'cancel', 'close']);
+</script>
+
+<style scoped>
+.animate-fade-in {
+  animation: fadeIn 0.3s ease-out forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+</style>

--- a/hello-vue3/src/components/WeeklyReport/PhotoUploader.vue
+++ b/hello-vue3/src/components/WeeklyReport/PhotoUploader.vue
@@ -1,26 +1,26 @@
 <template>
   <div>
-    <label class="block text-sm font-medium text-stone-700 mb-1">上傳照片（需 4 張） <span class="text-red-500">*</span></label>
+    <label class="block text-sm font-medium text-stone-700 mb-1">上傳照片（最多 4 張） <span class="text-red-500">*</span></label>
     <input
       type="file"
       multiple
       accept="image/*"
       @change="handleFileUpload"
       class="w-full px-3 py-2 border border-stone-300 rounded-lg"
-      required
       aria-required="true"
     />
     <p class="text-sm text-stone-600 mt-1">已選擇 {{ modelValue.length }} 張照片</p>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap gird-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mt-4">
       <div
         v-for="(photo, index) in modelValue"
-        :key="index"
+        :key="photo.id"
         class="relative w-full"
       >
         <img
           :src="photo.preview"
           alt="預覽照片"
-          class="w-full h-32 object-cover rounded-lg border border-stone-300"
+          class="w-full h-32 object-cover rounded-lg border border-stone-300 cursor-pointer"
+          @click="openModal(index)"
         />
         <button
           @click="removePhoto(index)"
@@ -31,12 +31,37 @@
         </button>
       </div>
     </div>
+
+    <!-- 模態框 -->
+    <div
+      v-if="showModal"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      @click.self="closeModal"
+    >
+      <div class="bg-white rounded-lg p-4 max-w-3xl w-full">
+        <div class="relative">
+          <img
+            :src="modelValue[selectedIndex].preview"
+            alt="放大照片"
+            class="w-full max-h-[80vh] object-contain"
+          />
+          <button
+            @click="closeModal"
+            class="absolute top-2 right-2 bg-gray-800 text-white rounded-full w-8 h-8 flex items-center justify-center"
+            aria-label="關閉模態框"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { onMounted } from 'vue';
+import { onMounted, onUnmounted, ref } from 'vue';
 
+// 定義屬性
 const props = defineProps({
   modelValue: {
     type: Array,
@@ -44,30 +69,72 @@ const props = defineProps({
   }
 });
 
+// 定義事件
 const emit = defineEmits(['update:modelValue', 'error']);
 
+// 模態框狀態
+const showModal = ref(false);
+const selectedIndex = ref(0);
+
+// 生成唯一 ID
+const generateId = () => Math.random().toString(36).substr(2, 9);
+
+// 處理檔案上傳
 const handleFileUpload = (event) => {
   const files = Array.from(event.target.files);
-  if (files.length > 4) {
+  const currentPhotos = [...props.modelValue];
+  
+  // 檢查總數是否超過 4 張
+  if (currentPhotos.length + files.length > 4) {
     emit('error', '最多只能上傳 4 張照片！');
     event.target.value = '';
     return;
   }
+
+  // 建立新照片陣列
   const newPhotos = files.map(file => ({
+    id: generateId(),
     file,
     preview: URL.createObjectURL(file)
   }));
-  emit('update:modelValue', newPhotos);
+
+  // 合併現有照片和新照片
+  const updatedPhotos = [...currentPhotos, ...newPhotos];
+  emit('update:modelValue', updatedPhotos);
+  
+  // 清理輸入欄位
+  event.target.value = '';
 };
 
+// 移除照片
 const removePhoto = (index) => {
   const newPhotos = [...props.modelValue];
-  newPhotos.splice(index, 1);
+  const removedPhoto = newPhotos.splice(index, 1)[0];
+  // 釋放預覽 URL
+  URL.revokeObjectURL(removedPhoto.preview);
   emit('update:modelValue', newPhotos);
 };
 
-// 確認組件掛載
+// 開啟模態框
+const openModal = (index) => {
+  selectedIndex.value = index;
+  showModal.value = true;
+};
+
+// 關閉模態框
+const closeModal = () => {
+  showModal.value = false;
+};
+
+// 組件掛載時
 onMounted(() => {
   console.log('PhotoUploader.vue 已掛載');
+});
+
+// 組件卸載時清理所有預覽 URL
+onUnmounted(() => {
+  props.modelValue.forEach(photo => {
+    URL.revokeObjectURL(photo.preview);
+  });
 });
 </script>

--- a/hello-vue3/src/views/Competition.vue
+++ b/hello-vue3/src/views/Competition.vue
@@ -4,18 +4,18 @@
     <div class="max-w-5xl mx-auto">
       <!-- 標題 -->
       <h2 class="text-xl font-semibold text-stone-950 mb-4 flex items-center">
-        <svg class="w-6 h-6 mr-2 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
+        <svg class="w-6 h-6 mr-2 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2">
+          </path>
         </svg>
         競賽提報系統
       </h2>
       <!-- 學期選擇 -->
       <div class="mb-6">
         <label class="block text-sm font-medium text-stone-700 mb-1">選擇學期</label>
-        <select
-          v-model="selectedSemester"
-          class="w-full px-3 py-2 border border-stone-300 rounded-lg"
-        >
+        <select v-model="selectedSemester" class="w-full px-3 py-2 border border-stone-300 rounded-lg">
           <option value="113-1">113學年第一學期</option>
           <option value="113-2">113學年第二學期</option>
         </select>
@@ -25,43 +25,48 @@
         無法載入實習廠商資料，請檢查個人資料設定！
       </div>
       <!-- 兩欄佈局，調整右欄寬度 -->
-      <div v-else class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <!-- 左欄：競賽表單 -->
-        <div class="bg-white border-4 border-stone-950 rounded-xl p-6 shadow-xl lg:col-span-1">
-          <CompetitionForm
-            v-model="formData"
-            :semester="selectedSemester"
-          />
-        </div>
-        <!-- 右欄：參賽者與文件上傳 -->
-        <div class="bg-white border-4 border-stone-950 rounded-xl p-6 shadow-xl lg:col-span-2">
-          <Participants
-            v-model="formData.participants"
-            :default-participant="defaultParticipant"
-          />
+    <div v-else class="grid grid-cols-1 lg:grid-cols-10 gap-6">
+      <!-- 左欄：競賽表單 -->
+      <div class="bg-white border-4 border-stone-950 rounded-xl p-8 shadow-xl lg:col-span-4">
+        <CompetitionForm v-model="formData" :semester="selectedSemester" />
+      </div>
+      <!-- 右欄：參賽者與文件上傳 -->
+      <div class="bg-white border-4 border-stone-950 rounded-xl p-8 shadow-xl lg:col-span-6">
+        <div class="max-w-full">
+          <Participants v-model="formData.participants" :default-participant="defaultParticipant" />
           <Supervisors v-model="formData.supervisors" />
           <FileUploader v-model="formData.proofDocuments" />
           <button
             @click="handleSubmit"
             class="mt-4 w-full px-4 py-2 bg-green-500 text-white rounded-full font-semibold shadow-lg hover:bg-yellow-500 hover:text-stone-950 transition-all duration-300 flex items-center justify-center"
           >
-            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"></path>
+            <svg
+              class="w-5 h-5 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+              ></path>
             </svg>
             提交競賽提報
           </button>
         </div>
       </div>
     </div>
+    </div>
 
     <!-- 簡單錯誤提示 -->
     <div v-if="showErrorModal" class="fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center z-50">
       <div class="bg-white rounded-lg p-6 border-4 border-stone-950 shadow-xl max-w-sm w-11/12">
         <h3 class="text-lg font-semibold text-stone-950 mb-4">{{ errorMessage }}</h3>
-        <button
-          @click="showErrorModal = false"
-          class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-yellow-500 hover:text-stone-950"
-        >
+        <button @click="showErrorModal = false"
+          class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-yellow-500 hover:text-stone-950">
           確定
         </button>
       </div>
@@ -168,6 +173,7 @@ const handleSubmit = () => {
 .home-card {
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
+
 .home-card:hover {
   transform: scale(1.02);
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);

--- a/hello-vue3/src/views/GradeManagement.vue
+++ b/hello-vue3/src/views/GradeManagement.vue
@@ -9,22 +9,22 @@
         <AcademicCapIcon class="w-7 h-7 mr-2 text-Ghibli-blue" /> 實習成績記錄
       </h2>
 
-      <!-- 篩選與操作區域 -->
+      <!-- 篩選與操作區 -->
       <div class="flex flex-col md:flex-row gap-4 mb-6">
         <div class="flex-1">
           <label class="block text-sm font-medium text-stone-700 mb-1">搜尋姓名</label>
           <input
-            v-model="searchName"
+            v-model.trim="searchName"
             type="text"
             placeholder="輸入學生姓名"
-            class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-Ghibli-blue"
+            class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-Ghibli-blue"
           />
         </div>
         <div class="flex-1">
           <label class="block text-sm font-medium text-stone-700 mb-1">成績範圍</label>
           <select
             v-model="scoreFilter"
-            class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-Ghibli-blue"
+            class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-Ghibli-blue"
           >
             <option value="">全部</option>
             <option value="90-100">90-100</option>
@@ -33,451 +33,242 @@
             <option value="below-70">低於 70</option>
           </select>
         </div>
-        <div class="flex space-x-4">
-          <button
-            @click="openBatchEditModal"
-            class="px-6 py-2 bg-Ghibli-blue text-white rounded-full font-semibold shadow-lg hover:bg-Ghibli-yellow hover:text-stone-950 transition-all duration-300 flex items-center"
-          >
+        <div class="flex items-end space-x-4">
+          <button @click="clearFilters" class="px-6 py-2 bg-gray-500 text-white rounded-full font-semibold hover:bg-gray-600 flex items-center">
+            <XIcon class="w-5 h-5 mr-2" /> 清除篩選
+          </button>
+          <button @click="openBatchEditModal" class="px-6 py-2 bg-Ghibli-blue text-white rounded-full font-semibold hover:bg-Ghibli-yellow flex items-center">
             <PencilIcon class="w-5 h-5 mr-2" /> 批量編輯
           </button>
-          <button
-            @click="exportToCSV"
-            class="px-6 py-2 bg-Ghibli-green text-white rounded-full font-semibold shadow-lg hover:bg-Ghibli-yellow hover:text-stone-950 transition-all duration-300 flex items-center"
-          >
-            <DocumentDownloadIcon class="w-5 h-5 mr-2" /> 導出 CSV
+          <!-- 匯出CSV按鈕 -->
+          <button @click="exportCSV" class="px-6 py-2 bg-green-600 text-white rounded-full font-semibold hover:bg-green-700 flex items-center">
+            <ArrowDownTrayIcon class="w-5 h-5 mr-2" /> 匯出CSV
           </button>
         </div>
       </div>
 
       <!-- 成績表格 -->
-      <div class="overflow-x-auto">
-        <table class="w-full text-left border-collapse" role="grid" aria-label="實習成績與時數記錄">
+      <div class="overflow-x-auto rounded-lg border border-stone-300">
+        <table class="w-full text-left border-collapse" role="grid">
           <thead>
             <tr class="bg-Ghibli-skin text-stone-950">
-              <th class="py-3 px-4 font-semibold" scope="col">姓名</th>
-              <th class="py-3 px-4 font-semibold" scope="col">實習項目</th>
-              <th class="py-3 px-4 font-semibold" scope="col">成績</th>
-              <th class="py-3 px-4 font-semibold" scope="col">評語</th>
-              <th class="py-3 px-4 font-semibold" scope="col">實習時數</th>
-              <th class="py-3 px-4 font-semibold" scope="col">操作</th>
+              <th class="py-3 px-4 font-semibold text-sm">姓名</th>
+              <th class="py-3 px-4 font-semibold text-sm">實習項目</th>
+              <th class="py-3 px-4 font-semibold text-sm">成績</th>
+              <th class="py-3 px-4 font-semibold text-sm">評語</th>
+              <th class="py-3 px-4 font-semibold text-sm">實習時數</th>
+              <th class="py-3 px-4 font-semibold text-sm">操作</th>
             </tr>
           </thead>
           <tbody>
             <tr
-              v-for="(record, index) in filteredRecords"
-              :key="index"
-              class="border-b border-stone-300 hover:bg-Ghibli-skin/30"
+              v-for="(r, idx) in filteredRecords"
+              :key="r.id"
+              class="border-b border-stone-200 hover:bg-Ghibli-skin/30"
             >
-              <td class="py-3 px-4">{{ record.name }}</td>
-              <td class="py-3 px-4">{{ record.project }}</td>
-              <td class="py-3 px-4">
-                <span :class="getScoreClass(record.score)">{{ record.score }}</span>
+              <td class="py-3 px-4 text-sm">{{ r.name }}</td>
+              <td class="py-3 px-4 text-sm">{{ r.project }}</td>
+              <td class="py-3 px-4 text-sm">
+                <span :class="getScoreClass(r.score)">{{ r.score }}</span>
               </td>
-              <td class="py-3 px-4">{{ record.comment || '-' }}</td>
-              <td class="py-3 px-4">{{ getStudentHours(record.name) }} 小時</td>
+              <td class="py-3 px-4 text-sm">{{ r.comment || '−' }}</td>
+              <td class="py-3 px-4 text-sm">{{ getHours(r.name) }} 小時</td>
               <td class="py-3 px-4">
                 <button
-                  @click="openSingleEditModal(record, index)"
-                  class="px-3 py-1 bg-Ghibli-blue text-white rounded-lg hover:bg-Ghibli-yellow hover:text-stone-950 transition-all duration-300"
+                  @click="openSingleEditModal(r, idx)"
+                  class="px-3 py-1 bg-Ghibli-blue text-white rounded-lg text-sm hover:bg-Ghibli-yellow"
                 >
                   編輯
                 </button>
               </td>
             </tr>
             <tr v-if="filteredRecords.length === 0">
-              <td colspan="6" class="py-3 px-4 text-center text-gray-500">暫無成績記錄</td>
+              <td colspan="6" class="py-4 px-4 text-center text-gray-500 text-sm">暫無成績記錄</td>
             </tr>
           </tbody>
         </table>
       </div>
     </div>
 
-    <!-- 單一學生編輯 Modal -->
-    <ModalDialog
-      :visible="showSingleEditModal"
-      :message="`編輯學生 ${editRecord?.name} 的成績和評語`"
-      pendingAction="edit"
-      @confirm="saveSingleEdit"
-      @cancel="closeSingleEditModal"
-      @close="closeSingleEditModal"
-    >
-      <div class="mb-2">
-        <label class="block text-sm font-medium text-stone-700 mb-1">成績 (0-100)</label>
-        <input
-          v-model.number="editRecord.score"
-          type="number"
-          min="0"
-          max="100"
-          placeholder="輸入成績"
-          class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-Ghibli-blue"
-          required
-          aria-required="true"
-          @input="validateSingleScore"
-        />
-        <p v-if="singleError.score" class="text-Ghibli-red text-sm mt-1">{{ singleError.score }}</p>
-      </div>
-      <div>
-        <label class="block text-sm font-medium text-stone-700 mb-1">評語</label>
-        <textarea
-          v-model="editRecord.comment"
-          placeholder="輸入評語（可選）"
-          class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-Ghibli-blue"
-        ></textarea>
-      </div>
-    </ModalDialog>
+    <!-- 單一編輯 Modal (Teleport 到 body) -->
+    <teleport to="body">
+      <ModalDialog
+        v-if="showSingleEditModal"
+        :visible="showSingleEditModal"
+        :message="`編輯學生 ${editRecord.name} 的成績和評語`"
+        @confirm="saveSingleEdit"
+        @cancel="closeSingleEditModal"
+        @close="closeSingleEditModal"
+      >
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-stone-700 mb-1">成績 (0-100)</label>
+          <input
+            v-model.number="editRecord.score"
+            type="number" min="0" max="100"
+            class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-Ghibli-blue"
+            @input="validateSingleScore"
+          />
+          <p v-if="singleError.score" class="text-Ghibli-red text-sm mt-1">{{ singleError.score }}</p>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-stone-700 mb-1">評語 (最多200字)</label>
+          <textarea
+            v-model="editRecord.comment"
+            class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-Ghibli-blue resize-none"
+            maxlength="200"
+          ></textarea>
+        </div>
+      </ModalDialog>
+    </teleport>
 
-    <!-- 批量編輯 Modal -->
-    <ModalDialog
-      :visible="showBatchEditModal"
-      message="批量編輯學生成績和評語"
-      pendingAction="edit"
-      @confirm="saveBatchEdit"
-      @cancel="closeBatchEditModal"
-      @close="closeBatchEditModal"
-    >
-      <div class="max-h-96 overflow-y-auto">
-        <div
-          v-for="(record, index) in batchEditRecords"
-          :key="index"
-          class="mb-6 border-b border-stone-300 pb-4"
-        >
-          <h3 class="text-lg font-semibold text-stone-950 mb-2">{{ record.name }} - {{ record.project }}</h3>
-          <div class="mb-2">
-            <label class="block text-sm font-medium text-stone-700 mb-1">成績 (0-100)</label>
-            <input
-              v-model.number="record.score"
-              type="number"
-              min="0"
-              max="100"
-              placeholder="輸入成績"
-              class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-Ghibli-blue"
-              required
-              aria-required="true"
-              @input="validateBatchScore(index)"
-            />
-            <p v-if="batchErrors[index]?.score" class="text-Ghibli-red text-sm mt-1">{{ batchErrors[index].score }}</p>
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-stone-700 mb-1">評語</label>
-            <textarea
-              v-model="record.comment"
-              placeholder="輸入評語（可選）"
-              class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-Ghibli-blue"
-            ></textarea>
+    <!-- 批量編輯 Modal (Teleport 到 body) -->
+    <teleport to="body">
+      <ModalDialog
+        v-if="showBatchEditModal"
+        :visible="showBatchEditModal"
+        message="批量編輯學生成績和評語"
+        @confirm="saveBatchEdit"
+        @cancel="closeBatchEditModal"
+        @close="closeBatchEditModal"
+      >
+        <div class="max-h-96 overflow-y-auto pr-2">
+          <div
+            v-for="(r, i) in batchEditRecords"
+            :key="r.id"
+            class="mb-6 border-b border-stone-300 pb-4"
+          >
+            <h3 class="text-lg font-semibold text-stone-950 mb-2">{{ r.name }} - {{ r.project }}</h3>
+            <div class="mb-2">
+              <label class="block text-sm font-medium text-stone-700 mb-1">成績 (0-100)</label>
+              <input
+                v-model.number="r.score"
+                type="number" min="0" max="100"
+                class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-Ghibli-blue"
+                @input="validateBatchScore(i)"
+              />
+              <p v-if="batchErrors[i]?.score" class="text-Ghibli-red text-sm mt-1">{{ batchErrors[i].score }}</p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-stone-700 mb-1">評語 (最多200字)</label>
+              <textarea
+                v-model="r.comment"
+                class="w-full px-4 py-2	border border-stone-300 rounded-lg focus:ring-2 focus:ring-Ghibli-blue resize-none"
+                maxlength="200"
+              ></textarea>
+            </div>
           </div>
         </div>
-      </div>
-    </ModalDialog>
-
-    <!-- 導出確認 Modal -->
-    <ModalDialog
-      :visible="showExportModal"
-      message="確定要導出成績數據為 CSV 檔案嗎？"
-      pendingAction="export"
-      @confirm="confirmExport"
-      @cancel="closeExportModal"
-      @close="closeExportModal"
-    >
-      <p class="text-stone-700">成績數據將以 CSV 格式下載，包含姓名、實習項目、成績、評語和實習時數。</p>
-    </ModalDialog>
+      </ModalDialog>
+    </teleport>
   </section>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
-import { AcademicCapIcon, DocumentDownloadIcon, PencilIcon } from '@heroicons/vue/24/outline';
-import ModalDialog from '@/components/CheckIn/ModalDialog.vue';
+import { ref, computed } from 'vue';
+import { AcademicCapIcon, PencilIcon, XIcon, ArrowDownTrayIcon } from '@heroicons/vue/24/outline';
+import ModalDialog from '@/components/Grades/ModalDialog.vue';
 
-// 定義 props
-defineProps({
-  headerVisible: {
-    type: Boolean,
-    default: true
-  }
-});
+defineProps({ headerVisible: { type: Boolean, default: true } });
 
-// 模擬成績數據（實際應用中應從 API 獲取）
+// 資料
 const gradeRecords = ref([
-  { name: '張偉', project: 'AI 模型開發', score: 92, comment: '表現出色，積極參與' },
-  { name: '李娜', project: '數據分析', score: 85, comment: '認真負責，需加強創新' },
-  { name: '王芳', project: '前端開發', score: 78, comment: '穩定進步，細節需改進' },
-  { name: '陳明', project: '後端系統', score: 65, comment: '需更專注於任務' }
+  { id: '1', name: '張偉', project: 'AI 模型開發', score: 92, comment: '表現出色' },
+  { id: '2', name: '李娜', project: '數據分析', score: 85, comment: '需加強創新' },
+  { id: '3', name: '王芳', project: '前端開發', score: 78, comment: '細節需改進' },
+  { id: '4', name: '陳明', project: '後端系統', score: 65, comment: '需更專注' }
 ]);
-
-// 模擬學生實習時數（實際應用中應從 API 獲取）
 const studentHours = ref([
   { name: '張偉', hours: 120 },
   { name: '李娜', hours: 95 },
   { name: '王芳', hours: 80 },
-  { name: '陳明', hours: 60 },
-  { name: '劉洋', hours: 0 },
-  { name: '趙靜', hours: 0 }
+  { name: '陳明', hours: 60 }
 ]);
 
-// 獲取學生實習時數
-const getStudentHours = (name) => {
-  const student = studentHours.value.find(s => s.name === name);
-  return student ? student.hours : 0;
-};
-
-// 篩選狀態
+// 計算
+const getHours = name => studentHours.value.find(s => s.name === name)?.hours || 0;
 const searchName = ref('');
 const scoreFilter = ref('');
+const clearFilters = () => { searchName.value = ''; scoreFilter.value = ''; };
 
-// 計算過濾後的記錄
-const filteredRecords = computed(() => {
-  return gradeRecords.value.filter(record => {
-    const matchesName = record.name.toLowerCase().includes(searchName.value.toLowerCase());
-    let matchesScore = true;
-
-    if (scoreFilter.value !== '') {
-      if (scoreFilter.value === '90-100') matchesScore = record.score >= 90;
-      else if (scoreFilter.value === '80-89') matchesScore = record.score >= 80 && record.score < 90;
-      else if (scoreFilter.value === '70-79') matchesScore = record.score >= 70 && record.score < 80;
-      else if (scoreFilter.value === 'below-70') matchesScore = record.score < 70;
+const filteredRecords = computed(() =>
+  gradeRecords.value.filter(r => {
+    const byName = r.name.includes(searchName.value.trim());
+    let byScore = true;
+    if (scoreFilter.value) {
+      if (scoreFilter.value === 'below-70') byScore = r.score < 70;
+      else {
+        const [min, max] = scoreFilter.value.split('-').map(Number);
+        byScore = r.score >= min && r.score <= max;
+      }
     }
+    return byName && byScore;
+  })
+);
 
-    return matchesName && matchesScore;
-  });
-});
+const getScoreClass = score =>
+  score >= 90 ? 'text-Ghibli-green font-bold' :
+  score >= 80 ? 'text-Ghibli-blue' :
+  score >= 70 ? 'text-Ghibli-yellow' :
+  'text-Ghibli-red';
 
-// 根據成績返回樣式類
-const getScoreClass = score => {
-  if (score >= 90) return 'text-Ghibli-green font-bold';
-  if (score >= 80) return 'text-Ghibli-blue';
-  if (score >= 70) return 'text-Ghibli-yellow';
-  return 'text-Ghibli-red';
-};
+// 匯出 CSV
+function exportCSV() {
+  const headers = ['姓名', '實習項目', '成績', '評語', '實習時數'];
+  const rows = filteredRecords.value.map(r => [
+    r.name, r.project, r.score, r.comment || '', getHours(r.name)
+  ]);
+  const csvContent = [headers, ...rows]
+    .map(e => e.map(v => `"${v}"`).join(','))
+    .join('\n');
+  const blob = new Blob(["\uFEFF" + csvContent], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = 'student_grades.csv';
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
 
-// 組件初始化檢查
-onMounted(() => {
-  console.log('GradeManagement mounted, showExportModal:', showExportModal.value);
-  showExportModal.value = false; // 強制重置導出彈窗狀態
-  console.log('Initial gradeRecords:', gradeRecords.value);
-});
-
-// 單一學生編輯狀態
+// 單一編輯
 const showSingleEditModal = ref(false);
-const editRecord = ref(null);
+const editRecord = ref({ name: '', project: '', score: 0, comment: '', index: -1 });
 const singleError = ref({ score: '' });
-
-// 開啟單一學生編輯
-const openSingleEditModal = (record, index) => {
-  console.log('Opening single edit modal for:', record.name, 'index:', index);
-  editRecord.value = {
-    name: record.name,
-    project: record.project,
-    score: record.score ?? '',
-    comment: record.comment ?? '',
-    index
-  };
+function openSingleEditModal(r, idx) {
+  editRecord.value = { ...r, index: idx };
   singleError.value = { score: '' };
   showSingleEditModal.value = true;
-};
-
-// 驗證單一學生成績
-// eslint-disable-next-line no-unused-vars
-const validateSingleScore = () => {
-  const score = editRecord.value.score;
-  console.log('Validating single score:', score);
-  if (score === '' || score === null) {
-    singleError.value.score = '請輸入成績';
-  } else if (isNaN(score) || score < 0 || score > 100) {
-    singleError.value.score = '成績必須在 0-100 之間';
-  } else {
-    singleError.value.score = '';
-  }
-};
-
-// 儲存單一學生編輯
-const saveSingleEdit = async () => {
-  console.log('Saving single edit:', editRecord.value);
-  if (editRecord.value.score === '' || editRecord.value.score === null) {
-    singleError.value.score = '請輸入成績';
-    alert('請輸入有效成績！');
-    return;
-  }
-  if (isNaN(editRecord.value.score) || editRecord.value.score < 0 || editRecord.value.score > 100) {
-    singleError.value.score = '成績必須在 0-100 之間';
-    alert('成績必須在 0-100 之間！');
-    return;
-  }
-
-  if (!confirm('確定要儲存成績和評語修改嗎？')) {
-    return;
-  }
-
-  gradeRecords.value[editRecord.value.index] = {
-    name: editRecord.value.name,
-    project: editRecord.value.project,
-    score: Number(editRecord.value.score),
-    comment: editRecord.value.comment ? editRecord.value.comment.trim() : ''
-  };
-
-  console.log('Updated gradeRecords:', gradeRecords.value);
-
-  // TODO: 與後端 API 同步單筆記錄
-  /*
-  try {
-    await fetch(`/api/grades/${editRecord.value.name}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        score: gradeRecords.value[editRecord.value.index].score,
-        comment: gradeRecords.value[editRecord.value.index].comment
-      })
-    });
-  } catch (error) {
-    alert('儲存失敗，請稍後再試！');
-    return;
-  }
-  */
-
-  closeSingleEditModal();
-};
-
-// 關閉單一學生編輯
-const closeSingleEditModal = () => {
-  console.log('Closing single edit modal');
+}
+function validateSingleScore() {
+  const s = editRecord.value.score;
+  singleError.value.score =
+    s === ''     ? '請輸入成績' :
+    isNaN(s)||s<0||s>100 ? '成績必須在 0-100 之間' : '';
+}
+function saveSingleEdit() {
+  validateSingleScore();
+  if (singleError.value.score) return;
+  if (!confirm('確定要儲存？')) return;
+  const i = editRecord.value.index;
+  gradeRecords.value[i] = { ...gradeRecords.value[i], score: Number(editRecord.value.score), comment: editRecord.value.comment.trim() };
   showSingleEditModal.value = false;
-  editRecord.value = null;
-  singleError.value = { score: '' };
-};
+}
+function closeSingleEditModal() { showSingleEditModal.value = false; }
 
-// 批量編輯狀態
+// 批量編輯
 const showBatchEditModal = ref(false);
 const batchEditRecords = ref([]);
 const batchErrors = ref([]);
-
-// 開啟批量編輯
-const openBatchEditModal = () => {
-  console.log('Opening batch edit modal');
-  batchEditRecords.value = gradeRecords.value.map(record => ({
-    name: record.name,
-    project: record.project,
-    score: record.score ?? '',
-    comment: record.comment ?? ''
-  }));
-  batchErrors.value = [];
-  showBatchEditModal.value = true;
-};
-
-// 驗證批量編輯成績
-// eslint-disable-next-line no-unused-vars
-const validateBatchScore = (index) => {
-  const score = batchEditRecords.value[index].score;
-  console.log('Validating batch score:', score, 'index:', index);
-  if (score === '' || score === null) {
-    batchErrors.value[index] = { score: '請輸入成績' };
-  } else if (isNaN(score) || score < 0 || score > 100) {
-    batchErrors.value[index] = { score: '成績必須在 0-100 之間' };
-  } else {
-    batchErrors.value[index] = null;
-  }
-};
-
-// 儲存批量編輯
-const saveBatchEdit = async () => {
-  console.log('Saving batch edit:', batchEditRecords.value);
-  for (let i = 0; i < batchEditRecords.value.length; i++) {
-    const record = batchEditRecords.value[i];
-    if (record.score === '' || record.score === null) {
-      batchErrors.value[i] = { score: '請輸入成績' };
-      alert(`請為 ${record.name} 輸入有效成績！`);
-      return;
-    }
-    if (isNaN(record.score) || record.score < 0 || record.score > 100) {
-      batchErrors.value[i] = { score: '成績必須在 0-100 之間' };
-      alert(`學生 ${record.name} 的成績必須在 0-100 之間！`);
-      return;
-    }
-  }
-
-  if (!confirm('確定要儲存所有成績和評語修改嗎？')) {
-    return;
-  }
-
-  gradeRecords.value = batchEditRecords.value.map(record => ({
-    name: record.name,
-    project: record.project,
-    score: Number(record.score),
-    comment: record.comment ? record.comment.trim() : ''
-  }));
-
-  console.log('Updated gradeRecords:', gradeRecords.value);
-
-  // TODO: 與後端 API 同步
-  /*
-  try {
-    await fetch('/api/grades', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(gradeRecords.value)
-    });
-  } catch (error) {
-    alert('儲存失敗，請稍後再試！');
-    return;
-  }
-  */
-
-  closeBatchEditModal();
-};
-
-// 關閉批量編輯
-const closeBatchEditModal = () => {
-  console.log('Closing batch edit modal');
-  showBatchEditModal.value = false;
-  batchEditRecords.value = [];
-  batchErrors.value = [];
-};
-
-// 導出 CSV
-const showExportModal = ref(false);
-
-const exportToCSV = () => {
-  console.log('Opening export modal');
-  showExportModal.value = true;
-};
-
-const closeExportModal = () => {
-  console.log('Closing export modal');
-  showExportModal.value = false;
-};
-
-const confirmExport = () => {
-  console.log('Exporting to CSV');
-  const headers = ['姓名', '實習項目', '成績', '評語', '實習時數'];
-  const rows = gradeRecords.value.map(record => [
-    `"${record.name}"`,
-    `"${record.project}"`,
-    record.score,
-    `"${record.comment || '-'}"`,
-    getStudentHours(record.name)
-  ]);
-
-  const csvContent = [
-    headers.join(','),
-    ...rows.map(row => row.join(','))
-  ].join('\n');
-
-  const BOM = '\uFEFF';
-  const blob = new Blob([BOM + csvContent], { type: 'text/csv;charset=utf-8;' });
-  const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = 'internship_grades.csv';
-  link.click();
-  URL.revokeObjectURL(link.href);
-
-  closeExportModal();
-};
+function openBatchEditModal() { batchEditRecords.value = gradeRecords.value.map(r => ({ ...r })); batchErrors.value = []; showBatchEditModal.value = true; }
+function validateBatchScore(i) { const s = batchEditRecords.value[i].score; batchErrors.value[i] = s === '' ? { score: '請輸入成績' } : isNaN(s)||s<0||s>100 ? { score: '成績必須在 0-100 之間' } : null; }
+function saveBatchEdit() { batchEditRecords.value.forEach((_, i) => validateBatchScore(i)); if (batchErrors.value.some(e => e)) return; if (!confirm('確定要儲存所有？')) return; gradeRecords.value = batchEditRecords.value.map(r => ({ ...r, score: Number(r.score), comment: r.comment.trim() })); showBatchEditModal.value = false; }
+function closeBatchEditModal() { showBatchEditModal.value = false; }
 </script>
 
 <style scoped>
-.home-card {
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-.home-card:hover {
-  transform: scale(1.02);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
-}
+.home-card { transition: transform 0.3s, box-shadow 0.3s; }
+.home-card:hover { transform: scale(1.02); box-shadow: 0 10px 20px rgba(0,0,0,0.15); }
+table { min-width: 100% }
+th, td { white-space: nowrap }
+@media (max-width: 640px) { th, td { font-size: 0.75rem; padding: 0.5rem } }
 </style>

--- a/hello-vue3/src/views/GradeManagement.vue
+++ b/hello-vue3/src/views/GradeManagement.vue
@@ -1,6 +1,5 @@
 <template>
   <section class="w-full px-[10%] py-6 relative z-10">
-    <BallBackground :random="true" :randomColor="true" />
     <div
       class="home-card bg-white border-4 border-stone-950 rounded-xl p-8 shadow-xl opacity-0"
       :class="{ 'animate-fade-in-up-relative': headerVisible }"
@@ -36,10 +35,10 @@
         </div>
         <div class="flex space-x-4">
           <button
-            @click="openEditModal"
+            @click="openBatchEditModal"
             class="px-6 py-2 bg-Ghibli-blue text-white rounded-full font-semibold shadow-lg hover:bg-Ghibli-yellow hover:text-stone-950 transition-all duration-300 flex items-center"
           >
-            <PencilIcon class="w-5 h-5 mr-2" /> 編輯成績
+            <PencilIcon class="w-5 h-5 mr-2" /> 批量編輯
           </button>
           <button
             @click="exportToCSV"
@@ -60,6 +59,7 @@
               <th class="py-3 px-4 font-semibold" scope="col">成績</th>
               <th class="py-3 px-4 font-semibold" scope="col">評語</th>
               <th class="py-3 px-4 font-semibold" scope="col">實習時數</th>
+              <th class="py-3 px-4 font-semibold" scope="col">操作</th>
             </tr>
           </thead>
           <tbody>
@@ -75,27 +75,69 @@
               </td>
               <td class="py-3 px-4">{{ record.comment || '-' }}</td>
               <td class="py-3 px-4">{{ getStudentHours(record.name) }} 小時</td>
+              <td class="py-3 px-4">
+                <button
+                  @click="openSingleEditModal(record, index)"
+                  class="px-3 py-1 bg-Ghibli-blue text-white rounded-lg hover:bg-Ghibli-yellow hover:text-stone-950 transition-all duration-300"
+                >
+                  編輯
+                </button>
+              </td>
             </tr>
             <tr v-if="filteredRecords.length === 0">
-              <td colspan="5" class="py-3 px-4 text-center text-gray-500">暫無成績記錄</td>
+              <td colspan="6" class="py-3 px-4 text-center text-gray-500">暫無成績記錄</td>
             </tr>
           </tbody>
         </table>
       </div>
     </div>
 
-    <!-- 批量編輯成績 Modal -->
+    <!-- 單一學生編輯 Modal -->
     <ModalDialog
-      v-if="showEditModal"
-      message="編輯所有學生成績"
+      :visible="showSingleEditModal"
+      :message="`編輯學生 ${editRecord?.name} 的成績和評語`"
       pendingAction="edit"
-      @confirm="saveEdits"
-      @cancel="closeEditModal"
-      @close="closeEditModal"
+      @confirm="saveSingleEdit"
+      @cancel="closeSingleEditModal"
+      @close="closeSingleEditModal"
+    >
+      <div class="mb-2">
+        <label class="block text-sm font-medium text-stone-700 mb-1">成績 (0-100)</label>
+        <input
+          v-model.number="editRecord.score"
+          type="number"
+          min="0"
+          max="100"
+          placeholder="輸入成績"
+          class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-Ghibli-blue"
+          required
+          aria-required="true"
+          @input="validateSingleScore"
+        />
+        <p v-if="singleError.score" class="text-Ghibli-red text-sm mt-1">{{ singleError.score }}</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-stone-700 mb-1">評語</label>
+        <textarea
+          v-model="editRecord.comment"
+          placeholder="輸入評語（可選）"
+          class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-Ghibli-blue"
+        ></textarea>
+      </div>
+    </ModalDialog>
+
+    <!-- 批量編輯 Modal -->
+    <ModalDialog
+      :visible="showBatchEditModal"
+      message="批量編輯學生成績和評語"
+      pendingAction="edit"
+      @confirm="saveBatchEdit"
+      @cancel="closeBatchEditModal"
+      @close="closeBatchEditModal"
     >
       <div class="max-h-96 overflow-y-auto">
         <div
-          v-for="(record, index) in editRecords"
+          v-for="(record, index) in batchEditRecords"
           :key="index"
           class="mb-6 border-b border-stone-300 pb-4"
         >
@@ -111,7 +153,9 @@
               class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-Ghibli-blue"
               required
               aria-required="true"
+              @input="validateBatchScore(index)"
             />
+            <p v-if="batchErrors[index]?.score" class="text-Ghibli-red text-sm mt-1">{{ batchErrors[index].score }}</p>
           </div>
           <div>
             <label class="block text-sm font-medium text-stone-700 mb-1">評語</label>
@@ -127,22 +171,24 @@
 
     <!-- 導出確認 Modal -->
     <ModalDialog
-      v-if="showExportModal"
+      :visible="showExportModal"
       message="確定要導出成績數據為 CSV 檔案嗎？"
       pendingAction="export"
       @confirm="confirmExport"
-      @cancel="showExportModal = false"
-      @close="showExportModal = false"
-    />
+      @cancel="closeExportModal"
+      @close="closeExportModal"
+    >
+      <p class="text-stone-700">成績數據將以 CSV 格式下載，包含姓名、實習項目、成績、評語和實習時數。</p>
+    </ModalDialog>
   </section>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { AcademicCapIcon, DocumentDownloadIcon, PencilIcon } from '@heroicons/vue/24/outline';
 import ModalDialog from '@/components/CheckIn/ModalDialog.vue';
-import BallBackground from '@/components/Background/BallBackground.vue';
 
+// 定義 props
 defineProps({
   headerVisible: {
     type: Boolean,
@@ -158,7 +204,7 @@ const gradeRecords = ref([
   { name: '陳明', project: '後端系統', score: 65, comment: '需更專注於任務' }
 ]);
 
-// 模擬學生實習時數（實際應用中應從 API 獲取，類似 HistoryTable.vue 的 checkInRecords）
+// 模擬學生實習時數（實際應用中應從 API 獲取）
 const studentHours = ref([
   { name: '張偉', hours: 120 },
   { name: '李娜', hours: 95 },
@@ -203,49 +249,203 @@ const getScoreClass = score => {
   return 'text-Ghibli-red';
 };
 
-// 批量編輯狀態
-const showEditModal = ref(false);
-const editRecords = ref([]);
+// 組件初始化檢查
+onMounted(() => {
+  console.log('GradeManagement mounted, showExportModal:', showExportModal.value);
+  showExportModal.value = false; // 強制重置導出彈窗狀態
+  console.log('Initial gradeRecords:', gradeRecords.value);
+});
 
-const openEditModal = () => {
-  editRecords.value = gradeRecords.value.map(record => ({
+// 單一學生編輯狀態
+const showSingleEditModal = ref(false);
+const editRecord = ref(null);
+const singleError = ref({ score: '' });
+
+// 開啟單一學生編輯
+const openSingleEditModal = (record, index) => {
+  console.log('Opening single edit modal for:', record.name, 'index:', index);
+  editRecord.value = {
     name: record.name,
     project: record.project,
-    score: record.score,
-    comment: record.comment
-  }));
-  showEditModal.value = true;
+    score: record.score ?? '',
+    comment: record.comment ?? '',
+    index
+  };
+  singleError.value = { score: '' };
+  showSingleEditModal.value = true;
 };
 
-const saveEdits = () => {
-  for (const record of editRecords.value) {
-    if (record.score === null || record.score < 0 || record.score > 100) {
+// 驗證單一學生成績
+// eslint-disable-next-line no-unused-vars
+const validateSingleScore = () => {
+  const score = editRecord.value.score;
+  console.log('Validating single score:', score);
+  if (score === '' || score === null) {
+    singleError.value.score = '請輸入成績';
+  } else if (isNaN(score) || score < 0 || score > 100) {
+    singleError.value.score = '成績必須在 0-100 之間';
+  } else {
+    singleError.value.score = '';
+  }
+};
+
+// 儲存單一學生編輯
+const saveSingleEdit = async () => {
+  console.log('Saving single edit:', editRecord.value);
+  if (editRecord.value.score === '' || editRecord.value.score === null) {
+    singleError.value.score = '請輸入成績';
+    alert('請輸入有效成績！');
+    return;
+  }
+  if (isNaN(editRecord.value.score) || editRecord.value.score < 0 || editRecord.value.score > 100) {
+    singleError.value.score = '成績必須在 0-100 之間';
+    alert('成績必須在 0-100 之間！');
+    return;
+  }
+
+  if (!confirm('確定要儲存成績和評語修改嗎？')) {
+    return;
+  }
+
+  gradeRecords.value[editRecord.value.index] = {
+    name: editRecord.value.name,
+    project: editRecord.value.project,
+    score: Number(editRecord.value.score),
+    comment: editRecord.value.comment ? editRecord.value.comment.trim() : ''
+  };
+
+  console.log('Updated gradeRecords:', gradeRecords.value);
+
+  // TODO: 與後端 API 同步單筆記錄
+  /*
+  try {
+    await fetch(`/api/grades/${editRecord.value.name}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        score: gradeRecords.value[editRecord.value.index].score,
+        comment: gradeRecords.value[editRecord.value.index].comment
+      })
+    });
+  } catch (error) {
+    alert('儲存失敗，請稍後再試！');
+    return;
+  }
+  */
+
+  closeSingleEditModal();
+};
+
+// 關閉單一學生編輯
+const closeSingleEditModal = () => {
+  console.log('Closing single edit modal');
+  showSingleEditModal.value = false;
+  editRecord.value = null;
+  singleError.value = { score: '' };
+};
+
+// 批量編輯狀態
+const showBatchEditModal = ref(false);
+const batchEditRecords = ref([]);
+const batchErrors = ref([]);
+
+// 開啟批量編輯
+const openBatchEditModal = () => {
+  console.log('Opening batch edit modal');
+  batchEditRecords.value = gradeRecords.value.map(record => ({
+    name: record.name,
+    project: record.project,
+    score: record.score ?? '',
+    comment: record.comment ?? ''
+  }));
+  batchErrors.value = [];
+  showBatchEditModal.value = true;
+};
+
+// 驗證批量編輯成績
+// eslint-disable-next-line no-unused-vars
+const validateBatchScore = (index) => {
+  const score = batchEditRecords.value[index].score;
+  console.log('Validating batch score:', score, 'index:', index);
+  if (score === '' || score === null) {
+    batchErrors.value[index] = { score: '請輸入成績' };
+  } else if (isNaN(score) || score < 0 || score > 100) {
+    batchErrors.value[index] = { score: '成績必須在 0-100 之間' };
+  } else {
+    batchErrors.value[index] = null;
+  }
+};
+
+// 儲存批量編輯
+const saveBatchEdit = async () => {
+  console.log('Saving batch edit:', batchEditRecords.value);
+  for (let i = 0; i < batchEditRecords.value.length; i++) {
+    const record = batchEditRecords.value[i];
+    if (record.score === '' || record.score === null) {
+      batchErrors.value[i] = { score: '請輸入成績' };
+      alert(`請為 ${record.name} 輸入有效成績！`);
+      return;
+    }
+    if (isNaN(record.score) || record.score < 0 || record.score > 100) {
+      batchErrors.value[i] = { score: '成績必須在 0-100 之間' };
       alert(`學生 ${record.name} 的成績必須在 0-100 之間！`);
       return;
     }
   }
-  gradeRecords.value = editRecords.value.map(record => ({
+
+  if (!confirm('確定要儲存所有成績和評語修改嗎？')) {
+    return;
+  }
+
+  gradeRecords.value = batchEditRecords.value.map(record => ({
     name: record.name,
     project: record.project,
-    score: record.score,
-    comment: record.comment
+    score: Number(record.score),
+    comment: record.comment ? record.comment.trim() : ''
   }));
-  closeEditModal();
+
+  console.log('Updated gradeRecords:', gradeRecords.value);
+
+  // TODO: 與後端 API 同步
+  /*
+  try {
+    await fetch('/api/grades', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(gradeRecords.value)
+    });
+  } catch (error) {
+    alert('儲存失敗，請稍後再試！');
+    return;
+  }
+  */
+
+  closeBatchEditModal();
 };
 
-const closeEditModal = () => {
-  showEditModal.value = false;
-  editRecords.value = [];
+// 關閉批量編輯
+const closeBatchEditModal = () => {
+  console.log('Closing batch edit modal');
+  showBatchEditModal.value = false;
+  batchEditRecords.value = [];
+  batchErrors.value = [];
 };
 
-// 導出 CSV 相關
+// 導出 CSV
 const showExportModal = ref(false);
 
 const exportToCSV = () => {
+  console.log('Opening export modal');
   showExportModal.value = true;
 };
 
+const closeExportModal = () => {
+  console.log('Closing export modal');
+  showExportModal.value = false;
+};
+
 const confirmExport = () => {
+  console.log('Exporting to CSV');
   const headers = ['姓名', '實習項目', '成績', '評語', '實習時數'];
   const rows = gradeRecords.value.map(record => [
     `"${record.name}"`,
@@ -260,7 +460,6 @@ const confirmExport = () => {
     ...rows.map(row => row.join(','))
   ].join('\n');
 
-  // 使用 UTF-8 with BOM 避免中文亂碼
   const BOM = '\uFEFF';
   const blob = new Blob([BOM + csvContent], { type: 'text/csv;charset=utf-8;' });
   const link = document.createElement('a');
@@ -269,7 +468,7 @@ const confirmExport = () => {
   link.click();
   URL.revokeObjectURL(link.href);
 
-  showExportModal.value = false;
+  closeExportModal();
 };
 </script>
 


### PR DESCRIPTION
重構 ModalDialog 組件

簡化事件處理（confirm / cancel / close）並統一 visible Prop 機制

移除多餘變數與 ESLint 警告

更新成績管理頁面

新增「單一編輯」及「批量編輯」成績功能

使用 <teleport> 將 ModalDialog 掛載到 body，避免被容器樣式截斷

修正 showSingleEditModal、showBatchEditModal 的條件渲染邏輯

新增 CSV 匯出功能

在操作區加入「匯出 CSV」按鈕

依當前篩選後的資料產生 UTF-8 BOM 編碼的 CSV 檔，並自動觸發下載

檔名固定為 student_grades.csv

其他優化

更新競賽類別選項顯示為繁體中文

優化選擇框與輸入框的寬度、表單與指導老師元件樣式

更新照片上傳元件，限制最多上傳 4 張並加入預覽 Modal
